### PR TITLE
Feature/optout durability

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -2,12 +2,11 @@
   (:require [mount.core :as mount]
             [clojure.tools.namespace.repl :as tn]
             [mamulengo.database :as database]
-            [mamulengo.config :as config]
-            [mamulengo.durability :as durable]))
+            [mamulengo.config :as config]))
 
 (defn start [config]
+  (mount/in-cljc-mode)
   (-> (mount.core/only #{#'config/mamulengo-cfg
-                         #'durable/durable-layer
                          #'database/ds-state
                          })
       (mount.core/with-args config)
@@ -20,8 +19,8 @@
   (stop)
   (tn/refresh))
 
-(defn go []
-  (start)
+(defn go [config]
+  (start config)
   :ready)
 
 (defn reset []

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject mamulengo "0.1.3"
+(defproject mamulengo "0.1.4"
   :description "Lightweight embedded database based on datascript for Clojure(Script)"
   :url "https://github.com/wandersoncferreira/mamulengo"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/mamulengo/core.cljc
+++ b/src/mamulengo/core.cljc
@@ -1,24 +1,20 @@
 (ns mamulengo.core
   #?@(:clj
-      [(:require [mount.core :refer [only with-args start stop in-cljc-mode]]
+      [(:require [mamulengo.config]
                  [mamulengo.database :as database]
-                 [mamulengo.config :as config])]
+                 [mount.core :as mount])]
       :cljs
-      [(:require [mamulengo.config :as config]
-                 [mount.core :refer [only with-args start stop in-cljc-mode]]
-                 [mamulengo.database :as database])]))
+      [(:require [mamulengo.config]
+                 [mamulengo.database :as database]
+                 [mount.core :as mount])]))
 
 (defn connect! [config]
-  (in-cljc-mode)
-  (-> (only #{#'config/mamulengo-cfg
-              #'database/durable-layer
-              #'database/ds-state
-              })
-      (with-args config)
-      (start)))
+  (mount/in-cljc-mode)
+  (-> (mount/with-args config)
+      (mount/start)))
 
 (defn disconnect! []
-  (stop))
+  (mount/stop))
 
 (def query! database/query!)
 (def transact! database/transact!)

--- a/src/mamulengo/durability.cljc
+++ b/src/mamulengo/durability.cljc
@@ -1,11 +1,11 @@
 (ns mamulengo.durability)
 
-(defmulti create-system-tables! :durable-layer)
+(defmulti create-system-tables! :durable-storage)
 
-(defmulti setup-clients-schema! :durable-layer)
+(defmulti setup-clients-schema! :durable-storage)
 
-(defmulti retrieve-all-facts! :durable-layer)
+(defmulti retrieve-all-facts! :durable-storage)
 
-(defmulti get-system-schema! :durable-layer)
+(defmulti get-system-schema! :durable-storage)
 
-(defmulti store! :durable-layer)
+(defmulti store! :durable-storage)

--- a/test/mamulengo/core_test.clj
+++ b/test/mamulengo/core_test.clj
@@ -8,7 +8,7 @@
 
 (deftest insert-into-database
   (testing "The database should insert all non-duplicated data."
-    (let [cfg {:durable-layer :h2
+    (let [cfg {:durable-storage :h2
                :durable-conf {:dbtype "h2:mem"
                               :dbname "test_mamulengo"}}]
       (sut/connect! cfg)

--- a/test/mamulengo/pg_impl_test.clj
+++ b/test/mamulengo/pg_impl_test.clj
@@ -10,7 +10,7 @@
 
 (deftest insert-planets-in-pg
   (testing "The implementation of postgresql should work too"
-    (let [cfg {:durable-layer :postgresql
+    (let [cfg {:durable-storage :postgresql
                :durable-conf {:dbtype "postgresql"
                               :dbname "mamulengo"
                               :password "test"


### PR DESCRIPTION
It fixes #2 so if you pass `:durable-layer :off` in the configuration map at startup time, you can use plan `datascript`.